### PR TITLE
Test on PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ php:
   - 5.6
   - 7.0
   - 7.3
+  - 7.4
 
 before_script:
   - set -ex

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ php:
   - 7.0
   - 7.3
 
-sudo: false
-
 before_script:
   - set -ex
   - composer install --no-interaction --prefer-dist


### PR DESCRIPTION
Also `sudo` is no longer needed and has no effect, so let's remove it: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration
